### PR TITLE
Change user agent to browser to stop cloudflare blocks

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,7 +19,7 @@ def get_doc(doc_link):
     headers = {}
     headers['Authorization'] = os.environ['INDIANA_API_KEY']
     headers['Content-Type'] = "application/pdf"
-    headers['User-Agent'] = 'openstates-in-proxy'
+    headers['User-Agent'] = 'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko'
     full_link = "https://api.iga.in.gov/" + doc_link + "?format=pdf"
     page = requests.get(full_link,headers=headers,verify=False)
 


### PR DESCRIPTION
Indiana started using cloudflare, which is blocking API requests from our custom UA. Changing it seems to make requests work again.

I've reached out to their IT in the hopes of getting the API whitelisted from cloudflare, for but the time being this will fix things.